### PR TITLE
Save to disk broken after resource split

### DIFF
--- a/vectordb/memory.py
+++ b/vectordb/memory.py
@@ -35,14 +35,18 @@ class Memory:
         """
         self.memory_file = memory_file
 
-        self.memory = (
-            [] if memory_file is None else Storage(memory_file).load_from_disk()
-        )
+        if memory_file is None:
+            self.memory = []
+            self.metadata_memory = []
+        else:
+            load = Storage(memory_file).load_from_disk()            
+            self.memory = [] if len(load) != 2 else load[0]
+            self.metadata_memory = [] if len(load) != 2 else load[1]
+
         if chunking_strategy is None:
             chunking_strategy = {"mode": "sliding_window"}
         self.chunker = Chunker(chunking_strategy)
 
-        self.metadata_memory = []
         self.metadata_index_counter = 0
         self.text_index_counter = 0
 
@@ -126,7 +130,7 @@ class Memory:
                 self.memory.append(entry)
 
         if memory_file is not None:
-            Storage(memory_file).save_to_disk(self.memory)
+            Storage(self.memory_file).save_to_disk([self.memory, self.metadata_memory])
 
     def search(
         self, query: str, top_n: int = 5, unique: bool = False, batch_results: str = "flatten"
@@ -187,7 +191,7 @@ class Memory:
         self.text_index_counter = 0
 
         if self.memory_file is not None:
-            Storage(self.memory_file).save_to_disk(self.memory)
+            Storage(self.memory_file).save_to_disk([self.memory, self.metadata_memory])
 
     def dump(self):
         """

--- a/vectordb/memory.py
+++ b/vectordb/memory.py
@@ -39,9 +39,9 @@ class Memory:
             self.memory = []
             self.metadata_memory = []
         else:
-            load = Storage(memory_file).load_from_disk()            
-            self.memory = [] if len(load) != 2 else load[0]
-            self.metadata_memory = [] if len(load) != 2 else load[1]
+            load = Storage(memory_file).load_from_disk()       
+            self.memory = [] if len(load) != 1 else load[0]["memory"]
+            self.metadata_memory = [] if len(load) != 1 else load[0]["metadata"]
 
         if chunking_strategy is None:
             chunking_strategy = {"mode": "sliding_window"}
@@ -130,7 +130,7 @@ class Memory:
                 self.memory.append(entry)
 
         if memory_file is not None:
-            Storage(self.memory_file).save_to_disk([self.memory, self.metadata_memory])
+            Storage(self.memory_file).save_to_disk([{"memory": self.memory, "metadata" :self.metadata_memory}])
 
     def search(
         self, query: str, top_n: int = 5, unique: bool = False, batch_results: str = "flatten"
@@ -191,7 +191,7 @@ class Memory:
         self.text_index_counter = 0
 
         if self.memory_file is not None:
-            Storage(self.memory_file).save_to_disk([self.memory, self.metadata_memory])
+            Storage(self.memory_file).save_to_disk([{"memory": self.memory, "metadata" :self.metadata_memory}])
 
     def dump(self):
         """


### PR DESCRIPTION
fixes #5 

As the storage currently takes a list of dicts I did it on an index basis, might be cleaner to change the storage to take a dictionary instead.
